### PR TITLE
Support parameters in translation keys

### DIFF
--- a/src/resources/js/modules/enso/__.js
+++ b/src/resources/js/modules/enso/__.js
@@ -18,10 +18,11 @@ export default function (key, params) {
     if(params) {
         translation = translation.replace(/:(\w*)/g, function(e, key) {
             let param = params[key.toLowerCase()] || key;
-            if(key === key.toUpperCase()) // param is uppercased
+            if(key === key.toUpperCase()) { // param is uppercased
                 param = param.toUpperCase();
-            else if(key[0] === key[0].toUpperCase()) // first letter is uppercased
+            } else if(key[0] === key[0].toUpperCase()) { // first letter is uppercased
                 param = param.charAt(0).toUpperCase() + param.slice(1);
+            }
             return param;
         });
     }

--- a/src/resources/js/modules/enso/__.js
+++ b/src/resources/js/modules/enso/__.js
@@ -1,0 +1,29 @@
+import store from '../../store';
+
+const __ = store.getters[ 'localisation/__' ];
+
+export default function (key, params) {
+    if (!store.getters[ 'localisation/isInitialised' ]) {
+        return key;
+    }
+
+    let translation = __(key);
+
+    if (typeof translation === 'undefined'
+        && store.state.localisation.keyCollector) {
+        store.dispatch('localisation/addMissingKey', key);
+    }
+
+    translation = translation || key;
+    if(params) {
+        translation = translation.replace(/:(\w*)/g, function(e, key) {
+            let param = params[key.toLowerCase()] || key;
+            if(key === key.toUpperCase()) // param is uppercased
+                param = param.toUpperCase();
+            else if(key[0] === key[0].toUpperCase()) // first letter is uppercased
+                param = param.charAt(0).toUpperCase() + param.slice(1);
+            return param;
+        });
+    }
+    return translation;
+}

--- a/src/resources/js/modules/enso/mixins/__.js
+++ b/src/resources/js/modules/enso/mixins/__.js
@@ -5,19 +5,12 @@ const __ = store.getters['localisation/__'];
 
 Vue.mixin({
     methods: {
-        __(key) {
+        __(key, params) {
             if (!store.getters['localisation/isInitialised']) {
                 return key;
             }
 
-            const translation = __(key);
-
-            if (typeof translation === 'undefined'
-                && store.state.localisation.keyCollector) {
-                store.dispatch('localisation/addMissingKey', key);
-            }
-
-            return translation || key;
+            return __(key, params);
         },
     },
 });

--- a/src/resources/js/modules/enso/mixins/__.js
+++ b/src/resources/js/modules/enso/mixins/__.js
@@ -1,16 +1,8 @@
 import Vue from 'vue';
-import store from '../../../store';
-
-const __ = store.getters['localisation/__'];
+import __ from '../__';
 
 Vue.mixin({
     methods: {
-        __(key, params) {
-            if (!store.getters['localisation/isInitialised']) {
-                return key;
-            }
-
-            return __(key, params);
-        },
+        __,
     },
 });

--- a/src/resources/js/modules/enso/mixins/__.js
+++ b/src/resources/js/modules/enso/mixins/__.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import __ from '../__';
+import __ from '../plugins/__';
 
 Vue.mixin({
     methods: {

--- a/src/resources/js/modules/enso/plugins/__.js
+++ b/src/resources/js/modules/enso/plugins/__.js
@@ -32,4 +32,4 @@ export default (key, params = null) => {
                 : param;
         })
         : translation;
-}
+};

--- a/src/resources/js/modules/enso/plugins/__.js
+++ b/src/resources/js/modules/enso/plugins/__.js
@@ -1,4 +1,4 @@
-import store from '../../store';
+import store from '../../../store';
 
 export default (key, params = null) => {
     if (!store.getters['localisation/isInitialised']) {

--- a/src/resources/js/store/localisation.js
+++ b/src/resources/js/store/localisation.js
@@ -6,10 +6,8 @@ export const state = {
 
 export const getters = {
     isInitialised: state => Object.keys(state.i18n).length > 0,
-    __: (state, getters, rootState, rootGetters) => (key) => {
-        const lang = rootGetters['preferences/lang']
-          || ((rootState.preferences && rootState.preferences.global)
-            ? rootState.preferences.global.lang : null);
+    __: (state, getters, rootState) => (key) => {
+        const lang = rootState.preferences.global;
 
         return state.i18n[lang]
             ? state.i18n[lang][key]

--- a/src/resources/js/store/localisation.js
+++ b/src/resources/js/store/localisation.js
@@ -12,8 +12,8 @@ export const getters = {
             ? rootState.preferences.global.lang : null);
 
         return state.i18n[lang]
-          ? state.i18n[lang][key]
-          : key;
+            ? state.i18n[lang][key]
+            : key;
     },
     documentTitle: (state, getters, rootState) =>
         title => (rootState.meta.extendedDocumentTitle

--- a/src/resources/js/store/localisation.js
+++ b/src/resources/js/store/localisation.js
@@ -6,11 +6,32 @@ export const state = {
 
 export const getters = {
     isInitialised: state => Object.keys(state.i18n).length > 0,
-    __: (state, getters, rootState, rootGetters) => (key) => {
-        const lang = rootGetters['preferences/lang'];
-        return state.i18n[lang]
+    __: (state, getters, rootState, rootGetters) => (key, params) => {
+        const lang = rootGetters['preferences/lang']
+            || ((rootState.preferences && rootState.preferences.global)
+                ? rootState.preferences.global.lang : null);
+
+        let translation = state.i18n[lang]
             ? state.i18n[lang][key]
             : key;
+
+        if (typeof translation === 'undefined'
+            && rootState.localisation.keyCollector) {
+                store.dispatch('localisation/addMissingKey', key);
+        }
+
+        translation = translation || key;
+        if(params) {
+            translation = translation.replace(/:(\w*)/g, function(e, key) {
+                let param = params[key.toLowerCase()];
+                if(key === key.toUpperCase()) // param is uppercased
+                    param = param.toUpperCase();
+                else if(key[0] === key[0].toUpperCase()) // first letter is uppercased
+                    param = param.charAt(0).toUpperCase() + param.slice(1);
+                return param;
+            });
+        }
+        return translation;
     },
     documentTitle: (state, getters, rootState) =>
         title => (rootState.meta.extendedDocumentTitle

--- a/src/resources/js/store/localisation.js
+++ b/src/resources/js/store/localisation.js
@@ -8,30 +8,12 @@ export const getters = {
     isInitialised: state => Object.keys(state.i18n).length > 0,
     __: (state, getters, rootState, rootGetters) => (key, params) => {
         const lang = rootGetters['preferences/lang']
-            || ((rootState.preferences && rootState.preferences.global)
-                ? rootState.preferences.global.lang : null);
+          || ((rootState.preferences && rootState.preferences.global)
+            ? rootState.preferences.global.lang : null);
 
-        let translation = state.i18n[lang]
-            ? state.i18n[lang][key]
-            : key;
-
-        if (typeof translation === 'undefined'
-            && rootState.localisation.keyCollector) {
-                store.dispatch('localisation/addMissingKey', key);
-        }
-
-        translation = translation || key;
-        if(params) {
-            translation = translation.replace(/:(\w*)/g, function(e, key) {
-                let param = params[key.toLowerCase()];
-                if(key === key.toUpperCase()) // param is uppercased
-                    param = param.toUpperCase();
-                else if(key[0] === key[0].toUpperCase()) // first letter is uppercased
-                    param = param.charAt(0).toUpperCase() + param.slice(1);
-                return param;
-            });
-        }
-        return translation;
+        return state.i18n[lang]
+          ? state.i18n[lang][key]
+          : key;
     },
     documentTitle: (state, getters, rootState) =>
         title => (rootState.meta.extendedDocumentTitle

--- a/src/resources/js/store/localisation.js
+++ b/src/resources/js/store/localisation.js
@@ -6,7 +6,7 @@ export const state = {
 
 export const getters = {
     isInitialised: state => Object.keys(state.i18n).length > 0,
-    __: (state, getters, rootState, rootGetters) => (key, params) => {
+    __: (state, getters, rootState, rootGetters) => (key) => {
         const lang = rootGetters['preferences/lang']
           || ((rootState.preferences && rootState.preferences.global)
             ? rootState.preferences.global.lang : null);


### PR DESCRIPTION
Closes https://github.com/laravel-enso/Localisation/issues/51

Example Usage: (js counterpart of [Laravel's implementation](https://laravel.com/docs/5.7/localization#replacing-parameters-in-translation-strings))

`__('Hello :name :Name :NAME', {name:this.$store.state.user.person.name})`  
Given "jonas" as name it would translate (by default) to `Hello jonas Jonas JONAS`

Please also see notes in https://github.com/laravel-enso/Localisation/issues/51#issuecomment-444149731 regarding `addMissingKeys`