### PR TITLE
adds query scope to user group, improves user policy

### DIFF
--- a/src/app/Http/Controllers/Administration/User/UserController.php
+++ b/src/app/Http/Controllers/Administration/User/UserController.php
@@ -60,9 +60,9 @@ class UserController extends Controller
 
         $user->fill($request->validated());
 
-        $this->authorize('handle-after', $user);
+        $this->authorize('update', $user);
 
-        $user->update($request->validated());
+        $user->save($request->validated());
 
         if (collect($user->getChanges())->keys()->contains('password')) {
             event(new PasswordReset($user));

--- a/src/app/Http/Controllers/Administration/User/UserController.php
+++ b/src/app/Http/Controllers/Administration/User/UserController.php
@@ -60,9 +60,7 @@ class UserController extends Controller
 
         $user->fill($request->validated());
 
-        if ($user->isDirty('role_id')) {
-            $this->authorize('change-role', $user);
-        }
+        $this->authorize('handle-after', $user);
 
         $user->update($request->validated());
 

--- a/src/app/Http/Controllers/Administration/UserGroup/UserGroupSelectController.php
+++ b/src/app/Http/Controllers/Administration/UserGroup/UserGroupSelectController.php
@@ -10,5 +10,8 @@ class UserGroupSelectController extends Controller
 {
     use OptionsBuilder;
 
-    protected $model = UserGroup::class;
+    public function query()
+    {
+        return UserGroup::visible();
+    }
 }

--- a/src/app/Models/UserGroup.php
+++ b/src/app/Models/UserGroup.php
@@ -34,4 +34,11 @@ class UserGroup extends Model
 
         parent::delete();
     }
+
+    public function scopeVisible($query)
+    {
+        return auth()->user()->belongsToAdminGroup()
+            ? $query
+            : $query->whereId(auth()->user()->group_id);
+    }
 }

--- a/src/app/Policies/UserPolicy.php
+++ b/src/app/Policies/UserPolicy.php
@@ -3,6 +3,7 @@
 namespace LaravelEnso\Core\app\Policies;
 
 use LaravelEnso\Core\app\Models\User;
+use LaravelEnso\RoleManager\app\Models\Role;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class UserPolicy
@@ -19,10 +20,10 @@ class UserPolicy
     public function handle(User $user, User $targetUser)
     {
         return ! $targetUser->isAdmin()
-            && $targetUser->group_id === $user->id;
+            && $targetUser->group_id === $user->group_id;
     }
 
-    public function handleAfter(User $user, User $targetUser)
+    public function update(User $user, User $targetUser)
     {
         return $targetUser->isDirty('role_id')
             ? $this->canChangeRole($user, $targetUser) && ! $targetUser->isDirty('group_id')
@@ -45,6 +46,7 @@ class UserPolicy
     private function canChangeRole(User $user, User $targetUser)
     {
         return  $user->id !== $targetUser->id
-            && ! ($targetUser->isAdmin() && ! $user->isAdmin());
+            && ! $targetUser->isAdmin()
+            && Role::visible()->whereId($targetUser->role_id)->first() !== null;
     }
 }


### PR DESCRIPTION
This commit ensures that users outside the Admin group can only create users within their own group. It also restricts the ability of non-admin users to switch groups.
